### PR TITLE
Add changes to adapt to new backend response types

### DIFF
--- a/src/Components/Pages/Create/CreateInvoice.tsx
+++ b/src/Components/Pages/Create/CreateInvoice.tsx
@@ -117,10 +117,10 @@ export const CreateInvoice: FunctionComponent<CreateInvoiceProps> = ({ }) => {
             const invoiceContractService = new InvoiceContractService(ROOT_PAYABLE_NAME)
 
             setMessages([
-                parseSignMessage({typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract', value: await invoiceContractService.generateCreateInvoiceBase64Message(createResult.markerCreationDetail, address)}, MsgExecuteContract.deserializeBinary),
                 parseSignMessage(createResult.scopeGenerationDetail.writeScopeRequest, MsgWriteScopeRequest.deserializeBinary),
                 parseSignMessage(createResult.scopeGenerationDetail.writeSessionRequest, MsgWriteSessionRequest.deserializeBinary),
                 parseSignMessage(createResult.scopeGenerationDetail.writeRecordRequest, MsgWriteRecordRequest.deserializeBinary),
+                parseSignMessage({typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract', value: await invoiceContractService.generateCreateInvoiceBase64Message(createResult.payablesContractExecutionDetail, address)}, MsgExecuteContract.deserializeBinary),
             ])
             setRedirect(`/invoices/${invoice?.getInvoiceUuid()?.getValue()}`)
 

--- a/src/Services/InvoiceContractService.ts
+++ b/src/Services/InvoiceContractService.ts
@@ -2,9 +2,9 @@ import { WasmService } from 'Services';
 import { MsgExecuteContract } from '@provenanceio/wallet-lib/lib/proto/cosmwasm/wasm/v1/tx_pb'
 import { Coin } from '@provenanceio/wallet-lib/lib/proto/cosmos/base/v1beta1/coin_pb'
 import { Any } from '@provenanceio/wallet-lib/lib/proto/google/protobuf/any_pb'
-import { QueryInvoiceSettings, QueryInvoiceSettingsResponse, RegisterPayableMarker } from '../models';
+import { QueryInvoiceSettings, QueryInvoiceSettingsResponse, RegisterPayable } from '../models';
 import { FEE_DENOM } from 'consts';
-import { MarkerCreationDetail } from 'hooks';
+import { PayablesContractExecutionDetail } from 'hooks';
 
 export class InvoiceContractService {
     wasmService = new WasmService()
@@ -27,18 +27,17 @@ export class InvoiceContractService {
         return this.wasmService.queryWasmCustom<QueryInvoiceSettings, QueryInvoiceSettingsResponse>(await this.getContractAddress(), new QueryInvoiceSettings())
     }
 
-    async generateCreateInvoiceBase64Message(markerDetail: MarkerCreationDetail, address: string): Promise<string> {
+    async generateCreateInvoiceBase64Message(contractDetail: PayablesContractExecutionDetail, address: string): Promise<string> {
         const [contractAddr, contractConfig] = await Promise.all([
             this.getContractAddress(),
             this.getContractConfig()
         ])
         const message = new MsgExecuteContract()
-            .setMsg(Buffer.from(new RegisterPayableMarker()
-                .setMarkerAddress(markerDetail.markerAddress)
-                .setMarkerDenom(markerDetail.markerDenom)
-                .setScopeId(markerDetail.scopeId)
-                .setPayableDenom(markerDetail.invoiceDenom)
-                .setPayableTotal(`${markerDetail.invoiceTotal}`)
+            .setMsg(Buffer.from(new RegisterPayable()
+                .setPayableUuid(contractDetail.payableUuid)
+                .setScopeId(contractDetail.scopeId)
+                .setPayableDenom(contractDetail.invoiceDenom)
+                .setPayableTotal(`${contractDetail.invoiceTotal}`)
                 .toJson()
             , 'utf-8').toString('base64'))
             .setFundsList([new Coin().setAmount(contractConfig.onboarding_cost).setDenom(contractConfig.onboarding_denom)])

--- a/src/consts/network.ts
+++ b/src/consts/network.ts
@@ -7,6 +7,6 @@ export const WALLET_URL = PRODUCTION ? 'https://wallet.provenance.io' : 'https:/
 export const ROOT_NAME = 'wallettest3.pb'
 export const FEE_DENOM = 'nhash'
 
-// export const BASE_URL = 'http://localhost:13459/service-invoice/v1'
+// export const BASE_URL = 'http://localhost:13459/v1'
 export const BASE_URL = 'https://test.figure.tech/service-invoice/v1'
-export const ROOT_PAYABLE_NAME = 'payablestest8.pb'
+export const ROOT_PAYABLE_NAME = 'payablestest11.pb'

--- a/src/hooks/useCreateInvoice.ts
+++ b/src/hooks/useCreateInvoice.ts
@@ -3,9 +3,8 @@ import { Invoice } from "../proto/invoice_protos_pb"
 import { useWalletConnect } from '@provenanceio/walletconnect-js'
 import { urlSafeBase64ToBase64 } from "../util"
 
-export interface MarkerCreationDetail {
-    markerDenom: string,
-    markerAddress: string,
+export interface PayablesContractExecutionDetail {
+    payableUuid: string,
     scopeId: string,
     invoiceDenom: string,
     invoiceTotal: number,
@@ -13,7 +12,7 @@ export interface MarkerCreationDetail {
 
 export interface CreateInvoiceResponse {
     invoice: any,
-    markerCreationDetail: MarkerCreationDetail,
+    payablesContractExecutionDetail: PayablesContractExecutionDetail,
     scopeGenerationDetail: {
         writeScopeRequest: any,
         writeSessionRequest: any,

--- a/src/models/InvoiceContract.ts
+++ b/src/models/InvoiceContract.ts
@@ -1,4 +1,3 @@
-import { string } from "prop-types"
 import { ContractMsg } from "./ContractBase"
 
 export class QueryInvoiceSettings {
@@ -20,43 +19,36 @@ export interface QueryInvoiceSettingsResponse {
     oracle_address: string,
 }
 
-export class RegisterPayableMarker extends ContractMsg {
-    register_payable_marker: {
-        marker_address: string,
-        marker_denom: string,
+export class RegisterPayable extends ContractMsg {
+    register_payable: {
+        payable_uuid: string,
         scope_id: string,
         payable_denom: string,
         payable_total: string,
     } = {
-        marker_address: '',
-        marker_denom: '',
+        payable_uuid: '',
         scope_id: '',
         payable_denom: '',
         payable_total: '',
     }
 
-    setMarkerAddress(marker_address: string): RegisterPayableMarker {
-        this.register_payable_marker.marker_address = marker_address
+    setPayableUuid(payable_uuid: string): RegisterPayable {
+        this.register_payable.payable_uuid = payable_uuid
         return this
     }
 
-    setMarkerDenom(marker_denom: string): RegisterPayableMarker {
-        this.register_payable_marker.marker_denom = marker_denom
+    setScopeId(scope_id: string): RegisterPayable {
+        this.register_payable.scope_id = scope_id
         return this
     }
 
-    setScopeId(scope_id: string): RegisterPayableMarker {
-        this.register_payable_marker.scope_id = scope_id
+    setPayableDenom(payable_denom: string): RegisterPayable {
+        this.register_payable.payable_denom = payable_denom
         return this
     }
 
-    setPayableDenom(payable_denom: string): RegisterPayableMarker {
-        this.register_payable_marker.payable_denom = payable_denom
-        return this
-    }
-
-    setPayableTotal(payable_total: string): RegisterPayableMarker {
-        this.register_payable_marker.payable_total = payable_total
+    setPayableTotal(payable_total: string): RegisterPayable {
+        this.register_payable.payable_total = payable_total
         return this
     }
 }


### PR DESCRIPTION
The backend had some changes to its response payloads and database structure.  These changes will interact with a new contract at `payablestest11` and swap the message send order to execute the payables smart contract last, ensuring that the scope has been created before it runs.