### PR TITLE
Add Received Invoices Tab

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ import { SidebarLayout, SidebarLink } from "./Components/Layout/Sidebar";
 import { ListInvoices } from "./Components/Pages/List/ListInvoices";
 import { CreateInvoice } from "./Components/Pages/Create/CreateInvoice";
 import { InvoiceDetails } from "Components/Pages/Details";
+import { InvoiceBills } from "Components/Pages/Bills";
 
 const Wrapper = styled.div`
   background: ${PRIMARY_BACKGROUND};
@@ -117,7 +118,8 @@ export const App = () => {
                 <Header>InVoice</Header>
                 {connected ? (
                   <>
-                    <SidebarLink to="/">My Invoices</SidebarLink>
+                    <SidebarLink to="/">Sent Invoices</SidebarLink>
+                    <SidebarLink to="/bills">Received Invoices</SidebarLink>
                     <SidebarLink to="/create">Create Invoice</SidebarLink>
                     <Disconnect
                       walletConnectService={wcs}
@@ -137,6 +139,7 @@ export const App = () => {
             {connected && (
               <Routes>
                 <Route path="/" element={<ListInvoices />} />
+                <Route path="/bills" element={<InvoiceBills />} />
                 <Route path="/create" element={<CreateInvoice />} />
                 <Route path="/:uuid" element={<InvoiceDetails />} />
                 <Route path="*" element={<ListInvoices />} />

--- a/src/Components/Pages/Bills/InvoiceBills.tsx
+++ b/src/Components/Pages/Bills/InvoiceBills.tsx
@@ -1,0 +1,104 @@
+import { FunctionComponent, useMemo } from "react";
+import { useMyBills } from "hooks/useMyBills";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import { TitleHeader } from "Components/Headers";
+import { currencyFormatter } from "util/currency";
+import { calculateTotal, distinctInvoiceDenoms, invoiceTotal } from "util/proto";
+import { FormWrapper } from "Components/Form";
+import { Colors } from 'consts';
+import { Invoice } from "proto/invoice_protos_pb";
+
+const TotalDetails = styled.div`
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+    align-items: center;
+`
+
+const BillTable = styled.div`
+    width: 100%;
+    margin-top: 30px;
+    color: ${Colors.DARK};
+`
+
+const BillRowWrapper = styled.div`
+    display: grid;
+    grid-template-columns: 2fr 2fr 2fr;
+    border-top: 1px solid black;
+    padding: 10px;
+    align-items: center;
+
+    color: ${Colors.TEXT};
+    &:hover {
+        background: rgba(0, 0, 0, .2);
+    }
+
+    > *:last-child {
+        display: flex;
+        justify-content: flex-end;
+    }
+`
+
+const BillHeaderWrapper = styled(BillRowWrapper)`
+    border-top: none;
+    font-weight: bold;
+    &:hover {
+        background: transparent;
+    }
+`
+
+const TableElement = styled.div`
+    font-size: 1.2rem;
+`
+
+const BillHeader = () => <BillHeaderWrapper>
+    <TableElement>Description</TableElement>
+    <TableElement>Sender</TableElement>
+    <TableElement>Amount</TableElement>
+</BillHeaderWrapper>
+
+interface BillRowProps {
+    invoice: Invoice
+}
+
+const BillRow: FunctionComponent<BillRowProps> = ({ invoice }) => {
+    const paymentDenom = invoice.getPaymentDenom()
+    const formatter = useMemo(() => currencyFormatter(paymentDenom), [paymentDenom])
+
+    return <Link to={`/${invoice.getInvoiceUuid()?.getValue()}`}>
+        <BillRowWrapper>
+            <TableElement>{invoice.getDescription()}</TableElement>
+            <TableElement>{invoice.getFromAddress()}</TableElement>
+            <TableElement><b>{formatter(invoiceTotal(invoice))}</b></TableElement>
+        </BillRowWrapper>
+    </Link>
+}
+
+interface InvoiceBillsProps {
+
+}
+
+export const InvoiceBills: FunctionComponent<InvoiceBillsProps> = ({ }) => {
+    const { data: invoices, isLoading, isError } = useMyBills()
+
+    if (isLoading) {
+        return <div>Loading...</div>
+    }
+
+    if (isError) {
+        return <div>Error fetching bills!</div>
+    }
+
+    const totals = <TotalDetails>
+        <TitleHeader title="Total Amount Billed">{invoices && calculateTotal(invoices)} {invoices && distinctInvoiceDenoms(invoices).join()}</TitleHeader>
+        <TitleHeader title="Total Invoices Billed to You">{invoices?.length || 0}</TitleHeader>
+    </TotalDetails>
+
+    return <FormWrapper title="Bills" headerDetails={totals}>
+        {invoices && <BillTable>
+            <BillHeader />
+            {invoices.map((invoice, i) => <BillRow key={invoice?.getInvoiceUuid()?.getValue() + `-${i}`} invoice={invoice} />)}
+        </BillTable>}
+    </FormWrapper>
+}

--- a/src/Components/Pages/Bills/InvoiceBills.tsx
+++ b/src/Components/Pages/Bills/InvoiceBills.tsx
@@ -92,10 +92,10 @@ export const InvoiceBills: FunctionComponent<InvoiceBillsProps> = ({ }) => {
 
     const totals = <TotalDetails>
         <TitleHeader title="Total Amount Billed">{invoices && calculateTotal(invoices)} {invoices && distinctInvoiceDenoms(invoices).join()}</TitleHeader>
-        <TitleHeader title="Total Invoices Billed to You">{invoices?.length || 0}</TitleHeader>
+        <TitleHeader title="Total Invoices Received">{invoices?.length || 0}</TitleHeader>
     </TotalDetails>
 
-    return <FormWrapper title="Bills" headerDetails={totals}>
+    return <FormWrapper title="Received Invoices" headerDetails={totals}>
         {invoices && <BillTable>
             <BillHeader />
             {invoices.map((invoice, i) => <BillRow key={invoice?.getInvoiceUuid()?.getValue() + `-${i}`} invoice={invoice} />)}

--- a/src/Components/Pages/Bills/index.ts
+++ b/src/Components/Pages/Bills/index.ts
@@ -1,0 +1,1 @@
+export * from './InvoiceBills'

--- a/src/Components/Pages/List/ListInvoices.tsx
+++ b/src/Components/Pages/List/ListInvoices.tsx
@@ -94,12 +94,12 @@ export const ListInvoices: FunctionComponent<ListInvoicesProps> = ({}) => {
     }
 
     const details = <TotalDetails>
-        <TitleHeader title="Total Amount Outstanding">{invoices && calculateTotal(invoices)} {invoices && distinctInvoiceDenoms(invoices).join()}</TitleHeader>
-        <TitleHeader title="Total Invoices Outstanding">{invoices?.length || 0}</TitleHeader>
+        <TitleHeader title="Total Amount Requested">{invoices && calculateTotal(invoices)} {invoices && distinctInvoiceDenoms(invoices).join()}</TitleHeader>
+        <TitleHeader title="Total Invoices Sent">{invoices?.length || 0}</TitleHeader>
         <Search maxWidth={300} />
     </TotalDetails>
 
-    return <FormWrapper title="Invoices" action={<Button onClick={() => navigate('/create')}>New Invoice</Button>} headerDetails={details}>
+    return <FormWrapper title="Sent Invoices" action={<Button onClick={() => navigate('/create')}>New Invoice</Button>} headerDetails={details}>
         {invoices && <InvoiceTable>
             <InvoiceHeader />
             {invoices.map((invoice, i) => <InvoiceRow key={invoice?.getInvoiceUuid()?.getValue() + `-${i}`} invoice={invoice}/>)}

--- a/src/Components/Pages/List/ListInvoices.tsx
+++ b/src/Components/Pages/List/ListInvoices.tsx
@@ -5,7 +5,7 @@ import { Button } from 'Components';
 import { Invoice } from "../../../proto/invoice_protos_pb";
 import styled from "styled-components";
 import { TitleHeader } from "../../Headers";
-import { calculateTotal, currencyFormatter, invoiceTotal } from "../../../util";
+import {calculateTotal, currencyFormatter, distinctInvoiceDenoms, invoiceTotal} from "../../../util";
 import { Search } from "../../Search";
 import { Colors } from 'consts';
 import { Link, useNavigate } from 'react-router-dom'
@@ -94,7 +94,7 @@ export const ListInvoices: FunctionComponent<ListInvoicesProps> = ({}) => {
     }
 
     const details = <TotalDetails>
-        <TitleHeader title="Total Amount Outstanding">{invoices && calculateTotal(invoices)} (VARIOUS CURRENCIES?)</TitleHeader>
+        <TitleHeader title="Total Amount Outstanding">{invoices && calculateTotal(invoices)} {invoices && distinctInvoiceDenoms(invoices).join()}</TitleHeader>
         <TitleHeader title="Total Invoices Outstanding">{invoices?.length || 0}</TitleHeader>
         <Search maxWidth={300} />
     </TotalDetails>

--- a/src/hooks/useMyBills.ts
+++ b/src/hooks/useMyBills.ts
@@ -1,0 +1,21 @@
+import { NameContractService } from "Services/NameContractService";
+import { BASE_URL, ROOT_NAME } from "consts";
+import { useQuery } from "react-query";
+import { useWalletConnect } from '@provenanceio/walletconnect-js';
+import { Invoice } from "proto/invoice_protos_pb";
+
+export const useMyBills = () => {
+    const { walletConnectState: { address } } = useWalletConnect()
+
+    return useQuery<Invoice[]>(['invoices'], async () => {
+        const names = await new NameContractService(ROOT_NAME).listNames(address)
+        const invoicePayload = await fetch(`${BASE_URL}/invoices/address/all`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                addresses: names,
+            }),
+        })
+        return (await invoicePayload.json()).map((invoice: string) => Invoice.deserializeBinary(Buffer.from(invoice, 'base64')))
+    })
+}

--- a/src/util/proto.ts
+++ b/src/util/proto.ts
@@ -18,3 +18,4 @@ export const lineItemPrice = (lineItem: LineItem) => +(lineItem?.getPrice()?.get
 export const lineItemTotal = (lineItem: LineItem) => lineItemPrice(lineItem) * lineItem.getQuantity()
 export const invoiceTotal = (invoice: Invoice) => invoice?.getLineItemsList().reduce((acc, item) => acc + lineItemTotal(item), 0)
 export const calculateTotal = (invoices: Invoice[]) => invoices.reduce((acc, invoice) => acc + invoiceTotal(invoice), 0)
+export const distinctInvoiceDenoms = (invoices: Invoice[]) => invoices.map(invoice => invoice.getPaymentDenom()).filter((value, index, self) => self.indexOf(value) === index)


### PR DESCRIPTION
Pretty much just ported over a lot of the design from the invoices list and tweaked some elements.  Used the concept discussed earlier - pull all of the user's name aliases from the name contract and pass them to the backend to get a total payload of invoices.  This will obviously need to be tweaked in the future for pagination if this app grows in scale, because sending / receiving a huge amount of json over the wire will eventually become cumbersome.  But this is a POC! WOOOO!

Changes display:
![Screen Shot 2022-02-08 at 3 21 21 PM](https://user-images.githubusercontent.com/49877044/153092484-1befe845-566c-48e6-8092-2fdd5bd6b37d.png)

![Screen Shot 2022-02-08 at 3 21 16 PM](https://user-images.githubusercontent.com/49877044/153092502-20912f3a-d863-4071-8f48-41ee656b4c33.png)

![Screen Shot 2022-02-08 at 3 21 28 PM](https://user-images.githubusercontent.com/49877044/153092536-450906c0-d6ef-43c1-84dc-c8d1515bca92.png)

