### PR TITLE
Support new contract messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "fe-invoice",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/Components/Pages/Create/CreateInvoice.tsx
+++ b/src/Components/Pages/Create/CreateInvoice.tsx
@@ -126,6 +126,7 @@ export const CreateInvoice: FunctionComponent<CreateInvoiceProps> = ({ }) => {
                 parseSignMessage(createResult.scopeGenerationDetail.writeSessionRequest, MsgWriteSessionRequest.deserializeBinary),
                 parseSignMessage(createResult.scopeGenerationDetail.writeRecordRequest, MsgWriteRecordRequest.deserializeBinary),
             ], [
+                // TODO: add this back into the other bulk transaction once attributes can be added to scopes that are created in the same transaction group
                 parseSignMessage({typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract', value: await invoiceContractService.generateCreateInvoiceBase64Message(createResult.payablesContractExecutionDetail, address)}, MsgExecuteContract.deserializeBinary),
             ]])
             setHandleComplete(() => () => navigate(`/invoices/${invoice?.getInvoiceUuid()?.getValue()}`))

--- a/src/Components/Pages/Create/CreateInvoice.tsx
+++ b/src/Components/Pages/Create/CreateInvoice.tsx
@@ -125,6 +125,7 @@ export const CreateInvoice: FunctionComponent<CreateInvoiceProps> = ({ }) => {
                 parseSignMessage(createResult.scopeGenerationDetail.writeScopeRequest, MsgWriteScopeRequest.deserializeBinary),
                 parseSignMessage(createResult.scopeGenerationDetail.writeSessionRequest, MsgWriteSessionRequest.deserializeBinary),
                 parseSignMessage(createResult.scopeGenerationDetail.writeRecordRequest, MsgWriteRecordRequest.deserializeBinary),
+            ], [
                 parseSignMessage({typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract', value: await invoiceContractService.generateCreateInvoiceBase64Message(createResult.payablesContractExecutionDetail, address)}, MsgExecuteContract.deserializeBinary),
             ]])
             setHandleComplete(() => () => navigate(`/invoices/${invoice?.getInvoiceUuid()?.getValue()}`))

--- a/src/hooks/useCreateInvoice.ts
+++ b/src/hooks/useCreateInvoice.ts
@@ -6,6 +6,7 @@ export interface PayablesContractExecutionDetail {
     payableType: string,
     payableUuid: string,
     scopeId: string,
+    oracleAddress: string,
     invoiceDenom: string,
     invoiceTotal: number,
 }

--- a/src/models/InvoiceContract.ts
+++ b/src/models/InvoiceContract.ts
@@ -52,12 +52,14 @@ export class RegisterPayable extends ContractMsg {
         payable_type: string,
         payable_uuid: string,
         scope_id: string,
+        oracle_address: string,
         payable_denom: string,
         payable_total: string,
     } = {
         payable_type: '',
         payable_uuid: '',
         scope_id: '',
+        oracle_address: '',
         payable_denom: '',
         payable_total: '',
     }
@@ -74,6 +76,11 @@ export class RegisterPayable extends ContractMsg {
 
     setScopeId(scope_id: string): RegisterPayable {
         this.register_payable.scope_id = scope_id
+        return this
+    }
+
+    setOracleAddress(oracle_address: string): RegisterPayable {
+        this.register_payable.oracle_address = oracle_address
         return this
     }
 

--- a/src/models/InvoiceContract.ts
+++ b/src/models/InvoiceContract.ts
@@ -15,8 +15,8 @@ export interface QueryInvoiceSettingsResponse {
     fee_collection_address: string,
     // Percentage of each transaction that is taken as fee
     fee_percent: string, // i.e. '0.5'
-    // Address of the oracle application that can withdraw excess fees after fee percent is removed from onboarding_cost
-    oracle_address: string,
+    // Whether or not the contract is running in 'local' mode
+    is_local: boolean,
 }
 
 export class QueryPayableState {

--- a/src/services/InvoiceContractService.ts
+++ b/src/services/InvoiceContractService.ts
@@ -36,17 +36,15 @@ export class InvoiceContractService {
             this.getContractAddress(),
             this.getContractConfig()
         ])
-        const messageJson = new RegisterPayable()
-            .setPayableType(contractDetail.payableType)
-            .setPayableUuid(contractDetail.payableUuid)
-            .setScopeId(contractDetail.scopeId)
-            .setOracleAddress(contractDetail.oracleAddress)
-            .setPayableDenom(contractDetail.invoiceDenom)
-            .setPayableTotal(`${contractDetail.invoiceTotal}`)
-            .toJson();
-        console.log(messageJson);
         const message = new MsgExecuteContract()
-            .setMsg(Buffer.from(messageJson, 'utf-8').toString('base64'))
+            .setMsg(Buffer.from(new RegisterPayable()
+                .setPayableType(contractDetail.payableType)
+                .setPayableUuid(contractDetail.payableUuid)
+                .setScopeId(contractDetail.scopeId)
+                .setOracleAddress(contractDetail.oracleAddress)
+                .setPayableDenom(contractDetail.invoiceDenom)
+                .setPayableTotal(`${contractDetail.invoiceTotal}`)
+                .toJson(), 'utf-8').toString('base64'))
             .setFundsList([new Coin().setAmount(contractConfig.onboarding_cost).setDenom(contractConfig.onboarding_denom)])
             .setContract(contractAddr)
             .setSender(address);
@@ -67,7 +65,7 @@ export class InvoiceContractService {
             .setMsg(Buffer.from(new MakePayment()
                 .setPayableUuid(payableUuid)
                 .toJson()
-            , 'utf-8').toString('base64'))
+                , 'utf-8').toString('base64'))
             .setFundsList([new Coin().setAmount(`${amount}`).setDenom(paymentDenom)])
             .setContract(contractAddr)
             .setSender(address);

--- a/src/services/InvoiceContractService.ts
+++ b/src/services/InvoiceContractService.ts
@@ -36,15 +36,17 @@ export class InvoiceContractService {
             this.getContractAddress(),
             this.getContractConfig()
         ])
+        const messageJson = new RegisterPayable()
+            .setPayableType(contractDetail.payableType)
+            .setPayableUuid(contractDetail.payableUuid)
+            .setScopeId(contractDetail.scopeId)
+            .setOracleAddress(contractDetail.oracleAddress)
+            .setPayableDenom(contractDetail.invoiceDenom)
+            .setPayableTotal(`${contractDetail.invoiceTotal}`)
+            .toJson();
+        console.log(messageJson);
         const message = new MsgExecuteContract()
-            .setMsg(Buffer.from(new RegisterPayable()
-                .setPayableType(contractDetail.payableType)
-                .setPayableUuid(contractDetail.payableUuid)
-                .setScopeId(contractDetail.scopeId)
-                .setPayableDenom(contractDetail.invoiceDenom)
-                .setPayableTotal(`${contractDetail.invoiceTotal}`)
-                .toJson()
-            , 'utf-8').toString('base64'))
+            .setMsg(Buffer.from(messageJson, 'utf-8').toString('base64'))
             .setFundsList([new Coin().setAmount(contractConfig.onboarding_cost).setDenom(contractConfig.onboarding_denom)])
             .setContract(contractAddr)
             .setSender(address);


### PR DESCRIPTION
The contract now returns an `is_local` flag in its state query, and requires a manually-provided `oracle_address` field when registering a payable.  The backend has been updated to include the oracle address in its response payload, so these tweaks just wire things up.

For posterity in future glances:
The message count needed to be tweaked from 1 to 2 (thanks for the help, Pierce) because a bug currently exists in the provenance codebase somewhere that prevents an attribute from being added to a scope when the scope is created within the same group of transactions.  Once the provenance bug is fixed, we should be able to move the separated contract transaction back into the core block of messages and only sign once, again.