### PR TITLE
Upgrade to ac v3.0.0 beta for testing

### DIFF
--- a/src/consts/network.ts
+++ b/src/consts/network.ts
@@ -11,7 +11,7 @@ export const FEE_DENOM = 'nhash'
 export const BASE_URL = 'https://test.figure.tech/service-invoice/v1'
 export const ROOT_PAYABLE_NAME = 'payablestest18.pb'
 
-export const ROOT_ASSET_CLASSIFICATION_NAME = 'assetclassificationalias.pb'
+export const ROOT_ASSET_CLASSIFICATION_NAME = 'acbeta.pb'
 export const PAYABLE_ASSET_TYPE = 'payable'
 export const ACCESS_ROUTE = PRODUCTION ? 'grpcs://figure.tech' : 'grpcs://test.figure.tech'
 export const ACCESS_ROUTE_NAME = 'gateway'

--- a/src/models/AssetClassificationContract.ts
+++ b/src/models/AssetClassificationContract.ts
@@ -2,49 +2,17 @@ import { ContractMsg } from "./ContractBase"
 
 export class QueryAssetDefinition {
     public query_asset_definition: {
-        qualifier?: AssetQualifier
+        asset_type?: string
     } = {}
 
-    static fromAssetType(asset_type: string): QueryAssetDefinition {
-        return new QueryAssetDefinition().setAssetType(asset_type)
-    }
-
-    static fromScopeSpecAddress(scope_spec_address: string): QueryAssetDefinition {
-        return new QueryAssetDefinition().setScopeSpecAddress(scope_spec_address)
-    }
-
     setAssetType(asset_type: string): QueryAssetDefinition {
-        this.query_asset_definition.qualifier = {
-            type: 'asset_type',
-            value: asset_type,
-        }
+        this.query_asset_definition.asset_type = asset_type
         return this
     }
-
-    setScopeSpecAddress(scope_spec_address: string): QueryAssetDefinition {
-        this.query_asset_definition.qualifier = {
-            type: 'scope_spec_address',
-            value: scope_spec_address,
-        }
-        return this
-    }
-}
-
-export type AssetQualifier = AssetTypeAssetQualifier | ScopeSpecAddressAssetQualifier
-
-export interface AssetTypeAssetQualifier {
-    type: 'asset_type',
-    value: string
-}
-
-export interface ScopeSpecAddressAssetQualifier {
-    type: 'scope_spec_address',
-    value: string
 }
 
 export interface QueryAssetDefinitionResponse {
     asset_type: string,
-    scope_spec_address: string,
     verifiers: VerifierDetail[],
     enabled: boolean,
 }

--- a/src/services/AssetClassificationContractService.ts
+++ b/src/services/AssetClassificationContractService.ts
@@ -23,7 +23,7 @@ export class AssetClassificationContractService {
     }
 
     async getInvoiceAssetDefinition(): Promise<QueryAssetDefinitionResponse> {
-        return this.wasmService.queryWasmCustom<QueryAssetDefinition, QueryAssetDefinitionResponse>(await this.getContractAddress(), QueryAssetDefinition.fromAssetType(PAYABLE_ASSET_TYPE))
+        return this.wasmService.queryWasmCustom<QueryAssetDefinition, QueryAssetDefinitionResponse>(await this.getContractAddress(), new QueryAssetDefinition().setAssetType(PAYABLE_ASSET_TYPE))
     }
 
     async generateClassifyAssetBase64Message(contractDetail: PayablesContractExecutionDetail, verifier: VerifierDetail, address: string): Promise<string> {


### PR DESCRIPTION
# Description
Change classification contract name to the beta instance, and update payload structures to the new formats in the v3.0.0 contract.  

## Note
I have tested this locally to onboard a new invoice with Kory's asset-onboarding changes, and everything appears to work as intended, proving that the service-invoice backend is backwards compatible.  